### PR TITLE
feat(gateway): HTTP Compression is enabled by default at the client side

### DIFF
--- a/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -38,7 +38,7 @@ public class ApiDeserializerTest extends AbstractTest {
         Endpoint endpoint = api.getProxy().getEndpoints().iterator().next();
         Assert.assertEquals("http://localhost:1234", endpoint.getTarget());
         Assert.assertNotNull(endpoint.getHttpClientOptions());
-        Assert.assertFalse(endpoint.getHttpClientOptions().isUseCompression());
+        Assert.assertTrue(endpoint.getHttpClientOptions().isUseCompression());
     }
 
     @Test

--- a/model/src/main/java/io/gravitee/definition/model/HttpClientOptions.java
+++ b/model/src/main/java/io/gravitee/definition/model/HttpClientOptions.java
@@ -27,7 +27,7 @@ public class HttpClientOptions {
     public static int DEFAULT_MAX_CONCURRENT_CONNECTIONS = 100;
     public static boolean DEFAULT_KEEP_ALIVE = true;
     public static boolean DEFAULT_PIPELINING = false;
-    public static boolean DEFAULT_USE_COMPRESSION = false;
+    public static boolean DEFAULT_USE_COMPRESSION = true;
 
     private long idleTimeout = DEFAULT_IDLE_TIMEOUT;
 


### PR DESCRIPTION
Closes gravitee-io/issues#343