### PR TITLE
fix: New endpoints are systematically created with ssl configuration

### DIFF
--- a/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/HttpClientSslOptionsDeserializer.java
+++ b/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/HttpClientSslOptionsDeserializer.java
@@ -94,11 +94,6 @@ public class HttpClientSslOptionsDeserializer extends AbstractStdScalarDeseriali
             }
         }
 
-        // No trustore defined -> trustAll is enabled
-        if (httpClientSslOptions.getTrustStore() == null) {
-            httpClientSslOptions.setTrustAll(true);
-        }
-
         JsonNode keyStoreNode = node.get("keyStore");
         if (keyStoreNode != null) {
             try {

--- a/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -521,10 +521,10 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-withclientoptions-null-pem.json", Api.class);
 
         HttpEndpoint endpoint = (HttpEndpoint) api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next();
-        Assert.assertNotNull(endpoint.getHttpClientOptions());
-        Assert.assertNotNull(endpoint.getHttpClientSslOptions());
-        Assert.assertNull(endpoint.getHttpClientSslOptions().getTrustStore());
-        Assert.assertTrue(endpoint.getHttpClientSslOptions().isTrustAll());
+        Assert.assertNotNull("must have client options", endpoint.getHttpClientOptions());
+        Assert.assertNotNull("must have ssl options", endpoint.getHttpClientSslOptions());
+        Assert.assertNull("must not have truststore", endpoint.getHttpClientSslOptions().getTrustStore());
+        Assert.assertFalse("must not trust all", endpoint.getHttpClientSslOptions().isTrustAll());
     }
 
     @Test
@@ -532,10 +532,10 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-withclientoptions-no-trustore.json", Api.class);
 
         HttpEndpoint endpoint = (HttpEndpoint) api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next();
-        Assert.assertNotNull(endpoint.getHttpClientOptions());
-        Assert.assertNotNull(endpoint.getHttpClientSslOptions());
-        Assert.assertNull(endpoint.getHttpClientSslOptions().getTrustStore());
-        Assert.assertTrue(endpoint.getHttpClientSslOptions().isTrustAll());
+        Assert.assertNotNull("must have client options", endpoint.getHttpClientOptions());
+        Assert.assertNotNull("must have ssl options", endpoint.getHttpClientSslOptions());
+        Assert.assertNull("must not have truststore", endpoint.getHttpClientSslOptions().getTrustStore());
+        Assert.assertFalse("must not trust all", endpoint.getHttpClientSslOptions().isTrustAll());
     }
 
     @Test


### PR DESCRIPTION
BREAKING CHANGE : this commit introduce a new behavior in the deserialization of the ssl configuration. Before, we consider `trustAll=TRUE` by default.
Now you need to configure it and the FALSE value is the default one.

This closes gravitee-io/issues#1811