### PR TITLE
fix(api): Avoid duplicate name for groups and endpoints

### DIFF
--- a/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/EndpointGroupDeserializer.java
+++ b/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/EndpointGroupDeserializer.java
@@ -73,7 +73,7 @@ public class EndpointGroupDeserializer extends StdScalarDeserializer<EndpointGro
                 if (endpoint != null) {
                     boolean added = endpoints.add(endpoint);
                     if (!added) {
-                        throw ctxt.mappingException("[api] API must have single endpoint names");
+                        throw ctxt.mappingException("[api] API endpoint names must be unique");
                     }
                 }
             }

--- a/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -402,6 +402,24 @@ public class ApiDeserializerTest extends AbstractTest {
         Assert.fail("should throw deser exception");
     }
 
+    @Test(expected = JsonMappingException.class)
+    public void shouldFailWithSameEndpointNamesInDifferentGroup() throws Exception {
+        load("/io/gravitee/definition/jackson/api-multiplesameendpointsindifferentgroups.json", Api.class);
+        Assert.fail("should throw deser exception");
+    }
+
+    @Test(expected = JsonMappingException.class)
+    public void shouldFailWithSameGroupEndpointNames() throws Exception {
+        load("/io/gravitee/definition/jackson/api-multiplesamegroupendpoints.json", Api.class);
+        Assert.fail("should throw deser exception");
+    }
+
+    @Test(expected = JsonMappingException.class)
+    public void shouldFailWithSameGroupEndpointNamesAndEndpointNames() throws Exception {
+        load("/io/gravitee/definition/jackson/api-multiplesamegroupendpointsandendpoints.json", Api.class);
+        Assert.fail("should throw deser exception");
+    }
+
     @Test
     public void definition_hostHeader_empty() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-empty-hostHeader.json", Api.class);

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/api-multiplesameendpointsindifferentgroups.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/api-multiplesameendpointsindifferentgroups.json
@@ -1,0 +1,34 @@
+{
+  "id": "my-api",
+  "name": "my-team-api",
+
+  "proxy": {
+    "context_path": "/team",
+    "groups": [
+      {
+        "name": "group1",
+        "endpoints": [
+          {
+            "name": "duplicate",
+            "target": "http://host1:8083/myapi"
+          }
+        ]
+      },
+      {
+        "name": "group2",
+        "endpoints": [
+          {
+            "name": "duplicate",
+            "target": "http://host1:8083/myapi"
+          }
+        ]
+      }
+    ],
+    "strip_context_path": false
+  },
+
+  "paths": {
+    "/*": [
+    ]
+  }
+}

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/api-multiplesamegroupendpoints.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/api-multiplesamegroupendpoints.json
@@ -1,0 +1,34 @@
+{
+  "id": "my-api",
+  "name": "my-team-api",
+
+  "proxy": {
+    "context_path": "/team",
+    "groups": [
+      {
+        "name": "duplicate",
+        "endpoints": [
+          {
+            "name": "endpoint1",
+            "target": "http://host1:8083/myapi"
+          }
+        ]
+      },
+      {
+        "name": "duplicate",
+        "endpoints": [
+          {
+            "name": "endpoint2",
+            "target": "http://host1:8083/myapi"
+          }
+        ]
+      }
+    ],
+    "strip_context_path": false
+  },
+
+  "paths": {
+    "/*": [
+    ]
+  }
+}

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/api-multiplesamegroupendpointsandendpoints.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/api-multiplesamegroupendpointsandendpoints.json
@@ -1,0 +1,34 @@
+{
+  "id": "my-api",
+  "name": "my-team-api",
+
+  "proxy": {
+    "context_path": "/team",
+    "groups": [
+      {
+        "name": "duplicate",
+        "endpoints": [
+          {
+            "name": "endpoint1",
+            "target": "http://host1:8083/myapi"
+          }
+        ]
+      },
+      {
+        "name": "group2",
+        "endpoints": [
+          {
+            "name": "duplicate",
+            "target": "http://host1:8083/myapi"
+          }
+        ]
+      }
+    ],
+    "strip_context_path": false
+  },
+
+  "paths": {
+    "/*": [
+    ]
+  }
+}

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/services/api-withservices-v2.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/services/api-withservices-v2.json
@@ -6,7 +6,7 @@
     "context_path": "/team",
     "groups": [
       {
-        "name": "default",
+        "name": "group-default",
         "endpoints": [
           {
             "name": "default",

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/services/api-withservices.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/services/api-withservices.json
@@ -6,7 +6,7 @@
     "context_path": "/team",
     "groups": [
       {
-        "name": "default",
+        "name": "group-default",
         "endpoints": [
           {
             "name": "default",

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty-v2.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty-v2.json
@@ -6,7 +6,7 @@
     "context_path": "/team",
     "groups": [
       {
-        "name": "default",
+        "name": "group-default",
         "endpoints": [
           {
             "name": "default",

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty.json
@@ -6,7 +6,7 @@
     "context_path": "/team",
     "groups": [
       {
-        "name": "default",
+        "name": "group-default",
         "endpoints": [
           {
             "name": "default",

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck-badUnit.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck-badUnit.json
@@ -6,7 +6,7 @@
     "context_path": "/team",
     "groups": [
       {
-        "name": "default",
+        "name": "group-default",
         "endpoints": [
           {
             "name": "default",

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck-noExpectation.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck-noExpectation.json
@@ -6,7 +6,7 @@
     "context_path": "/team",
     "groups": [
       {
-        "name": "default",
+        "name": "group-default",
         "endpoints": [
           {
             "name": "default",

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck-unitInLowerCase.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck-unitInLowerCase.json
@@ -6,7 +6,7 @@
     "context_path": "/team",
     "groups": [
       {
-        "name": "default",
+        "name": "group-default",
         "endpoints": [
           {
             "name": "default",

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck-v2-fromroot.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck-v2-fromroot.json
@@ -6,7 +6,7 @@
     "context_path": "/team",
     "groups": [
       {
-        "name": "default",
+        "name": "group-default",
         "endpoints": [
           {
             "name": "default",

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck-v2.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck-v2.json
@@ -6,7 +6,7 @@
     "context_path": "/team",
     "groups": [
       {
-        "name": "default",
+        "name": "group-default",
         "endpoints": [
           {
             "name": "default",

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/services/healtcheck/api-withservice-healthcheck.json
@@ -6,7 +6,7 @@
     "context_path": "/team",
     "groups": [
       {
-        "name": "default",
+        "name": "group-default",
         "endpoints": [
           {
             "name": "default",


### PR DESCRIPTION
fix gravitee-io/issues#1578