### PR TITLE
fix(requests): do not encode/decode query parameters by default

### DIFF
--- a/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/HttpClientOptionsDeserializer.java
+++ b/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/HttpClientOptionsDeserializer.java
@@ -97,10 +97,18 @@ public class HttpClientOptionsDeserializer extends AbstractStdScalarDeserializer
 
         JsonNode followRedirectsNode = node.get("followRedirects");
         if (followRedirectsNode != null) {
-            boolean useCompression = followRedirectsNode.asBoolean(HttpClientOptions.DEFAULT_FOLLOW_REDIRECTS);
-            httpClientOptions.setFollowRedirects(useCompression);
+            boolean followRedirects = followRedirectsNode.asBoolean(HttpClientOptions.DEFAULT_FOLLOW_REDIRECTS);
+            httpClientOptions.setFollowRedirects(followRedirects);
         } else {
             httpClientOptions.setFollowRedirects(HttpClientOptions.DEFAULT_FOLLOW_REDIRECTS);
+        }
+
+        JsonNode encodeURINode = node.get("encodeURI");
+        if (encodeURINode != null) {
+            boolean encodeURI = encodeURINode.asBoolean(HttpClientOptions.DEFAULT_ENCODE_URI);
+            httpClientOptions.setEncodeURI(encodeURI);
+        } else {
+            httpClientOptions.setEncodeURI(HttpClientOptions.DEFAULT_ENCODE_URI);
         }
 
         return httpClientOptions;

--- a/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/HttpClientOptionsSerializer.java
+++ b/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/HttpClientOptionsSerializer.java
@@ -43,6 +43,7 @@ public class HttpClientOptionsSerializer extends StdScalarSerializer<HttpClientO
         jgen.writeNumberField("maxConcurrentConnections", httpClientOptions.getMaxConcurrentConnections());
         jgen.writeBooleanField("useCompression", httpClientOptions.isUseCompression());
         jgen.writeBooleanField("followRedirects", httpClientOptions.isFollowRedirects());
+        jgen.writeBooleanField("encodeURI", httpClientOptions.isEncodeURI());
         jgen.writeEndObject();
     }
 }

--- a/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -284,6 +284,11 @@ public class ApiDeserializerTest extends AbstractTest {
         PEMTrustStore trustStore = (PEMTrustStore) endpoint.getHttpClientSslOptions().getTrustStore();
         Assert.assertNotNull(trustStore.getContent());
         Assert.assertNull(trustStore.getPath());
+        Assert.assertEquals(5000L, endpoint.getHttpClientOptions().getIdleTimeout());
+        Assert.assertEquals(5000L, endpoint.getHttpClientOptions().getConnectTimeout());
+        Assert.assertTrue(endpoint.getHttpClientOptions().isFollowRedirects());
+        Assert.assertTrue(endpoint.getHttpClientOptions().isKeepAlive());
+        Assert.assertTrue(endpoint.getHttpClientOptions().isEncodeURI());
     }
 
     @Test
@@ -299,9 +304,15 @@ public class ApiDeserializerTest extends AbstractTest {
     public void definition_withclientoptions_nooptions() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-withclientoptions-nooptions.json", Api.class);
 
-        Endpoint endpoint = api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next();
-        Assert.assertNotNull(((HttpEndpoint) endpoint).getHttpClientOptions());
-        Assert.assertNull(((HttpEndpoint) endpoint).getHttpClientSslOptions());
+        HttpEndpoint  endpoint = (HttpEndpoint) api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next();
+        Assert.assertNotNull(endpoint.getHttpClientOptions());
+        Assert.assertNull(endpoint.getHttpClientSslOptions());
+
+        Assert.assertEquals(HttpClientOptions.DEFAULT_IDLE_TIMEOUT, endpoint.getHttpClientOptions().getIdleTimeout());
+        Assert.assertEquals(HttpClientOptions.DEFAULT_CONNECT_TIMEOUT, endpoint.getHttpClientOptions().getConnectTimeout());
+        Assert.assertEquals(HttpClientOptions.DEFAULT_FOLLOW_REDIRECTS, endpoint.getHttpClientOptions().isFollowRedirects());
+        Assert.assertEquals(HttpClientOptions.DEFAULT_KEEP_ALIVE, endpoint.getHttpClientOptions().isKeepAlive());
+        Assert.assertEquals(HttpClientOptions.DEFAULT_ENCODE_URI, endpoint.getHttpClientOptions().isEncodeURI());
     }
 
     @Test

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/api-withclientoptions.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/api-withclientoptions.json
@@ -12,7 +12,8 @@
           "idleTimeout": 5000,
           "connectTimeout": 5000,
           "keepAlive": true,
-          "followRedirects": true
+          "followRedirects": true,
+          "encodeURI": true
         },
         "ssl": {
           "trustAll": true,

--- a/model/src/main/java/io/gravitee/definition/model/HttpClientOptions.java
+++ b/model/src/main/java/io/gravitee/definition/model/HttpClientOptions.java
@@ -29,6 +29,7 @@ public class HttpClientOptions {
     public static boolean DEFAULT_PIPELINING = false;
     public static boolean DEFAULT_USE_COMPRESSION = true;
     public static boolean DEFAULT_FOLLOW_REDIRECTS = false;
+    public static boolean DEFAULT_ENCODE_URI = false;
 
     private long idleTimeout = DEFAULT_IDLE_TIMEOUT;
     private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
@@ -38,6 +39,7 @@ public class HttpClientOptions {
     private int maxConcurrentConnections = DEFAULT_MAX_CONCURRENT_CONNECTIONS;
     private boolean useCompression = DEFAULT_USE_COMPRESSION;
     private boolean followRedirects = DEFAULT_FOLLOW_REDIRECTS;
+    private boolean encodeURI = DEFAULT_ENCODE_URI;
 
     public long getConnectTimeout() {
         return connectTimeout;
@@ -101,5 +103,13 @@ public class HttpClientOptions {
 
     public void setFollowRedirects(boolean followRedirects) {
         this.followRedirects = followRedirects;
+    }
+
+    public boolean isEncodeURI() {
+        return encodeURI;
+    }
+
+    public void setEncodeURI(boolean encodeURI) {
+        this.encodeURI = encodeURI;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>15</version>
+        <version>16</version>
     </parent>
 
     <groupId>io.gravitee.definition</groupId>


### PR DESCRIPTION
fix gravitee-io/issues#2557