### PR TITLE
fix(deserialization): Use a specific deserializer

### DIFF
--- a/model/src/main/java/io/gravitee/definition/model/endpoint/HttpEndpoint.java
+++ b/model/src/main/java/io/gravitee/definition/model/endpoint/HttpEndpoint.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.definition.model.*;
 import io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService;
+import io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckServiceDeserializer;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -143,20 +144,11 @@ public class HttpEndpoint extends Endpoint {
         }
     }
 
-    @JsonSetter("healthcheck")
-    public void setHealthCheckJson(Object healthCheck) {
-        if (healthCheck instanceof Boolean) {
-            return;
-        }
-        this.healthCheck = EndpointHealthCheckService.fromMap((HashMap<String, Object>) healthCheck);
-    }
-
-    @JsonGetter("healthcheck")
+    @JsonDeserialize(using = EndpointHealthCheckServiceDeserializer.class)
     public EndpointHealthCheckService getHealthCheck() {
         return healthCheck;
     }
 
-    @JsonIgnore
     public void setHealthCheck(EndpointHealthCheckService healthCheck) {
         this.healthCheck = healthCheck;
     }

--- a/model/src/main/java/io/gravitee/definition/model/services/healthcheck/EndpointHealthCheckService.java
+++ b/model/src/main/java/io/gravitee/definition/model/services/healthcheck/EndpointHealthCheckService.java
@@ -45,12 +45,4 @@ public class EndpointHealthCheckService extends HealthCheckService {
         return enabled ? new EndpointHealthCheckService() : null;
     }
 
-    public static EndpointHealthCheckService fromMap(HashMap<String, Object> map) {
-        EndpointHealthCheckService endpointHealthCheckService = new EndpointHealthCheckService();
-        endpointHealthCheckService.setEnabled((Boolean) map.get("enabled"));
-        endpointHealthCheckService.setInherit((Boolean) map.get("inherit"));
-        endpointHealthCheckService.setSchedule((String) map.get("schedule"));
-        endpointHealthCheckService.setSteps((List<Step>) map.get("steps"));
-        return endpointHealthCheckService;
-    }
 }

--- a/model/src/main/java/io/gravitee/definition/model/services/healthcheck/EndpointHealthCheckServiceDeserializer.java
+++ b/model/src/main/java/io/gravitee/definition/model/services/healthcheck/EndpointHealthCheckServiceDeserializer.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.services.healthcheck;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+import io.gravitee.definition.model.Property;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class EndpointHealthCheckServiceDeserializer extends StdScalarDeserializer<EndpointHealthCheckService> {
+
+    public EndpointHealthCheckServiceDeserializer() {
+        super(List.class);
+    }
+
+    @Override
+    public EndpointHealthCheckService deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException
+    {
+        JsonNode node = jp.getCodec().readTree(jp);
+
+        if (node.isObject()) {
+            return node.traverse(jp.getCodec()).readValueAs(EndpointHealthCheckService.class);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
In the Endpoint definition, "healthcheck" is an object.
But to keep legacy compatibility, we must handle the fact that sometimes, "healthcheck" is a boolean.
The try with Jackson annotation was not successful, so we go back to a specific deserializer.

This should have no impact on the swagger.json in the Management API.

Issue gravitee-io/issues#5570