### PR TITLE
feat: do not ser/deser empty condition in steps

### DIFF
--- a/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/StepDeserializer.java
+++ b/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/StepDeserializer.java
@@ -43,7 +43,10 @@ public class StepDeserializer extends StdScalarDeserializer<Step> {
         step.setPolicy(node.get("policy").asText());
         final JsonNode condition = node.get("condition");
         if (condition != null && !condition.isNull()) {
-            step.setCondition(condition.asText());
+            final String conditionStr = condition.asText();
+            if (!conditionStr.isBlank()) {
+                step.setCondition(conditionStr);
+            }
         }
         step.setConfiguration(node.get("configuration").toString());
         step.setEnabled(node.path("enabled").asBoolean(true));

--- a/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/StepSerializer.java
+++ b/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/StepSerializer.java
@@ -39,7 +39,7 @@ public class StepSerializer extends StdScalarSerializer<Step> {
         jgen.writeStringField("description", step.getDescription());
         jgen.writeBooleanField("enabled", step.isEnabled());
         jgen.writeStringField("policy", step.getPolicy());
-        if (step.getCondition() != null) {
+        if (step.getCondition() != null && !step.getCondition().isBlank()) {
             jgen.writeStringField("condition", step.getCondition());
         }
         jgen.writeFieldName("configuration");

--- a/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.definition.jackson.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -590,6 +591,23 @@ public class ApiDeserializerTest extends AbstractTest {
         assertEquals("rate-limit", rule.getPolicy());
         Assert.assertNotNull(rule.getConfiguration());
         assertTrue(rule.isEnabled());
+        assertNull(rule.getCondition());
+
+        Step ruleApiKey = flow.getPre().get(1);
+        Assert.assertNotNull(ruleApiKey);
+        assertEquals("Check API Key", ruleApiKey.getName());
+        assertEquals("api-key", ruleApiKey.getPolicy());
+        Assert.assertNotNull(ruleApiKey.getConfiguration());
+        assertTrue(ruleApiKey.isEnabled());
+        assertNull(ruleApiKey.getCondition());
+
+        Step ruleTransformHeaders = flow.getPre().get(2);
+        Assert.assertNotNull(ruleTransformHeaders);
+        assertEquals("Add HTTP headers", ruleTransformHeaders.getName());
+        assertEquals("transform-headers", ruleTransformHeaders.getPolicy());
+        Assert.assertNotNull(ruleTransformHeaders.getConfiguration());
+        assertTrue(ruleTransformHeaders.isEnabled());
+        assertEquals("a non empty condition", ruleTransformHeaders.getCondition());
 
         Collection<Plan> plans = api.getPlans();
         Assert.assertNotNull(plans);

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/api-defaultflow-expected.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/api-defaultflow-expected.json
@@ -46,7 +46,8 @@
       "description" : "Step description",
       "enabled" : true,
       "policy" : "transform-headers",
-      "configuration" : {"add-headers":"...."}
+      "configuration" : {"add-headers":"...."},
+      "condition": "a non empty condition"
     } ],
     "post" : [ {
       "name" : "url-rewriting",

--- a/jackson/src/test/resources/io/gravitee/definition/jackson/api-defaultflow.json
+++ b/jackson/src/test/resources/io/gravitee/definition/jackson/api-defaultflow.json
@@ -36,7 +36,8 @@
           "description": "Step description",
           "configuration": {
             "rate": "1 req/s"
-          }
+          },
+          "condition": ""
         },
         {
           "policy": "api-key",
@@ -52,7 +53,8 @@
           "description": "Step description",
           "configuration": {
             "add-headers": "...."
-          }
+          },
+          "condition": "a non empty condition"
         }
       ],
       "post": [


### PR DESCRIPTION
**Issue**

gravitee-io/issues#6886

**Description**

Do not serialize / deserialize empty condition on api steps
