### PR TITLE
Adjust `Rule` to have the correct shape for the OpenAPI definition

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>2.1.9</version>
+            <version>2.1.13</version>
         </dependency>
     </dependencies>
 </project>

--- a/model/src/main/java/io/gravitee/definition/model/Rule.java
+++ b/model/src/main/java/io/gravitee/definition/model/Rule.java
@@ -18,6 +18,7 @@ package io.gravitee.definition.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.http.HttpMethod;
+import io.swagger.v3.oas.annotations.Hidden;
 
 import java.io.Serializable;
 import java.util.EnumSet;
@@ -72,5 +73,11 @@ public class Rule extends HashMap<String, Object> /* This is to generate the cor
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    @Hidden
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty();
     }
 }

--- a/model/src/main/java/io/gravitee/definition/model/Rule.java
+++ b/model/src/main/java/io/gravitee/definition/model/Rule.java
@@ -15,21 +15,25 @@
  */
 package io.gravitee.definition.model;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.http.HttpMethod;
+
 import java.io.Serializable;
-import java.util.*;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class Rule implements Serializable {
+public class Rule extends HashMap<String, Object> /* This is to generate the correct Open-API definition*/implements Serializable {
 
     @JsonProperty("methods")
     private Set<HttpMethod> methods = EnumSet.allOf(HttpMethod.class);
 
-    @JsonProperty("policy")
+    @JsonIgnore
     private Policy policy;
 
     @JsonProperty("description")


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5018

**Description**

The generated `Rule` definition for Swagger / OpenAPI does not match the expected shape of the management REST-API. 

**Additional context**

 The `policy` must be mapped as additional property, since its name is a key of the `Rule` object
