### PR TITLE
fix: use GraviteeMapper instead of simple ObjectMapper

### DIFF
--- a/jackson/src/main/java/io/gravitee/definition/jackson/datatype/GraviteeMapper.java
+++ b/jackson/src/main/java/io/gravitee/definition/jackson/datatype/GraviteeMapper.java
@@ -37,7 +37,7 @@ public class GraviteeMapper extends ObjectMapper {
     private static final long serialVersionUID = 1L;
 
     public GraviteeMapper() {
-        registerModule(new ApiModule());
+        registerModule(new ApiModule(this));
         registerModule(new ServiceModule());
         registerModule(new HealthCheckModule());
         registerModule(new DynamicPropertyModule());

--- a/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ApiModule.java
+++ b/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ApiModule.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.jackson.datatype.api;
 
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.jackson.datatype.GraviteeModule;
 import io.gravitee.definition.jackson.datatype.api.deser.*;
 import io.gravitee.definition.jackson.datatype.api.deser.ssl.*;
@@ -40,7 +41,7 @@ public class ApiModule extends GraviteeModule {
     private static final long serialVersionUID = 1L;
 
     @SuppressWarnings("unchecked")
-    public ApiModule() {
+    public ApiModule(GraviteeMapper graviteeMapper) {
         super("api");
         // first deserializers
         addDeserializer(Api.class, new ApiDeserializer(Api.class));
@@ -52,7 +53,7 @@ public class ApiModule extends GraviteeModule {
         addDeserializer(HttpProxy.class, new HttpProxyDeserializer(HttpProxy.class));
         addDeserializer(HttpClientOptions.class, new HttpClientOptionsDeserializer(HttpClientOptions.class));
         addDeserializer(HttpClientSslOptions.class, new HttpClientSslOptionsDeserializer(HttpClientSslOptions.class));
-        addDeserializer(Endpoint.class, new EndpointDeserializer(Endpoint.class));
+        addDeserializer(Endpoint.class, new EndpointDeserializer(Endpoint.class, graviteeMapper));
         addDeserializer(Properties.class, new PropertiesDeserializer(Properties.class));
         addDeserializer(Property.class, new PropertyDeserializer(Property.class));
         addDeserializer(Cors.class, new CorsDeserializer(Cors.class));
@@ -84,7 +85,7 @@ public class ApiModule extends GraviteeModule {
         addSerializer(Properties.class, new PropertiesSerializer(Properties.class));
         addSerializer(Property.class, new PropertySerializer(Property.class));
         addSerializer(Cors.class, new CorsSerializer(Cors.class));
-        addSerializer(EndpointGroup.class, new EndpointGroupSerializer(EndpointGroup.class));
+        addSerializer(EndpointGroup.class, new EndpointGroupSerializer(EndpointGroup.class, graviteeMapper));
         addSerializer(Logging.class, new LoggingSerializer(Logging.class));
         addSerializer(JKSKeyStore.class, new JKSKeyStoreSerializer(JKSKeyStore.class));
         addSerializer(PEMKeyStore.class, new PEMKeyStoreSerializer(PEMKeyStore.class));

--- a/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/EndpointDeserializer.java
+++ b/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/EndpointDeserializer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.ssl.pem.PEMTrustStore;
 import java.io.IOException;
@@ -35,10 +36,11 @@ import java.util.*;
  */
 public class EndpointDeserializer extends StdScalarDeserializer<Endpoint> {
 
-    ObjectMapper mapper = new ObjectMapper();
+    private final GraviteeMapper mapper;
 
-    public EndpointDeserializer(Class<Endpoint> vc) {
+    public EndpointDeserializer(Class<Endpoint> vc, GraviteeMapper mapper) {
         super(vc);
+        this.mapper = mapper;
     }
 
     @Override

--- a/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/EndpointGroupSerializer.java
+++ b/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/EndpointGroupSerializer.java
@@ -15,12 +15,11 @@
  */
 package io.gravitee.definition.jackson.datatype.api.ser;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.EndpointGroup;
 import java.io.IOException;
@@ -32,14 +31,11 @@ import java.util.Set;
  */
 public class EndpointGroupSerializer extends StdScalarSerializer<EndpointGroup> {
 
-    static ObjectMapper mapper = new ObjectMapper();
+    private final GraviteeMapper mapper;
 
-    {
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    }
-
-    public EndpointGroupSerializer(Class<EndpointGroup> vc) {
+    public EndpointGroupSerializer(Class<EndpointGroup> vc, GraviteeMapper graviteeMapper) {
         super(vc);
+        this.mapper = graviteeMapper;
     }
 
     @Override

--- a/model/src/main/java/io/gravitee/definition/model/Endpoint.java
+++ b/model/src/main/java/io/gravitee/definition/model/Endpoint.java
@@ -157,6 +157,10 @@ public class Endpoint implements Serializable {
         this.healthCheck = healthCheck;
     }
 
+    public Set<EndpointStatusListener> getEndpointAvailabilityListeners() {
+        return this.listeners;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;


### PR DESCRIPTION
**Issue**

Related to:
 - https://github.com/gravitee-io/issues/issues/7250
 - https://github.com/gravitee-io/issues/issues/7135

**Description**
 
- Use `GraviteeMapper` instead of simple `ObjectMapper`, any reason to have used it in the first place @gravitee-io/archi?
- Add a getter for listeners in Endpoint