### PR TITLE
refactor: move stage at flow level

### DIFF
--- a/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
+++ b/jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import io.gravitee.definition.model.*;
 import io.gravitee.definition.model.Properties;
 import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.definition.model.flow.FlowStage;
 import io.gravitee.definition.model.plugins.resources.Resource;
 import io.gravitee.definition.model.services.Services;
 import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
@@ -170,6 +171,7 @@ public class ApiDeserializer extends StdScalarDeserializer<Api> {
                         jsonNode -> {
                             try {
                                 Flow flow = jsonNode.traverse(jp.getCodec()).readValueAs(Flow.class);
+                                flow.setStage(FlowStage.API);
                                 flows.add(flow);
                             } catch (IOException e) {
                                 logger.error("Flow {} can not be de-serialized", jsonNode.asText());
@@ -188,6 +190,7 @@ public class ApiDeserializer extends StdScalarDeserializer<Api> {
                         jsonNode -> {
                             try {
                                 Plan plan = jsonNode.traverse(jp.getCodec()).readValueAs(Plan.class);
+                                plan.getFlows().forEach(flow -> flow.setStage(FlowStage.PLAN));
                                 plans.add(plan);
                             } catch (IOException e) {
                                 logger.error("Plan {} can not be de-serialized", jsonNode.asText());

--- a/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -30,6 +30,7 @@ import io.gravitee.definition.model.Properties;
 import io.gravitee.definition.model.flow.Consumer;
 import io.gravitee.definition.model.flow.ConsumerType;
 import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.definition.model.flow.FlowStage;
 import io.gravitee.definition.model.flow.Step;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -584,6 +585,7 @@ public class ApiDeserializerTest extends AbstractTest {
         Assert.assertNotNull(consumer2);
         assertEquals("PRIVATE", consumer2.getConsumerId());
         assertEquals(ConsumerType.TAG, consumer2.getConsumerType());
+        assertEquals(FlowStage.API, flow.getStage());
 
         Step rule = flow.getPre().get(0);
         Assert.assertNotNull(rule);
@@ -618,6 +620,7 @@ public class ApiDeserializerTest extends AbstractTest {
         assertEquals("OAUTH2", api.getPlan("plan-1").getSecurity());
         assertEquals(2, api.getPlan("plan-1").getTags().size());
         assertEquals("PUBLISHED", api.getPlan("plan-1").getStatus());
+        assertEquals(FlowStage.PLAN, api.getPlan("plan-1").getFlows().get(0).getStage());
 
         assertEquals(FlowMode.DEFAULT, api.getFlowMode());
     }

--- a/model/src/main/java/io/gravitee/definition/model/flow/Flow.java
+++ b/model/src/main/java/io/gravitee/definition/model/flow/Flow.java
@@ -52,6 +52,15 @@ public class Flow implements Serializable {
     @JsonProperty("consumers")
     private List<Consumer> consumers;
 
+    /**
+     * In which stage the flow is configured.
+     * This data is useful to debug or improve logging.
+     * Ignored because only used internally.
+     * @return the stage of the Flow, see {@link FlowStage}.
+     */
+    @JsonIgnore
+    private FlowStage stage;
+
     public String getName() {
         return name;
     }
@@ -98,6 +107,14 @@ public class Flow implements Serializable {
 
     public void setMethods(Set<HttpMethod> methods) {
         this.methods = methods;
+    }
+
+    public FlowStage getStage() {
+        return stage;
+    }
+
+    public void setStage(FlowStage stage) {
+        this.stage = stage;
     }
 
     @JsonIgnore

--- a/model/src/main/java/io/gravitee/definition/model/flow/FlowStage.java
+++ b/model/src/main/java/io/gravitee/definition/model/flow/FlowStage.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.flow;
+
+/**
+ * In which stage the flow is configured
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public enum FlowStage {
+    PLATFORM,
+    PLAN,
+    API,
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7183

**Description**

move FlowStage computation from FlowResolver to Flow directly in the deserializer. It's not the best but it avoids some confusion on the gateway part.

